### PR TITLE
feat: Add support for nix-mode

### DIFF
--- a/separedit.el
+++ b/separedit.el
@@ -209,7 +209,7 @@ Taken from `markdown-code-lang-modes'."
                           common-lisp
                           racket-mode
                           scheme-mode))
-    (("#+")            . (python-mode ruby-mode)))
+    (("#+")            . (nix-mode python-mode ruby-mode)))
   "Alist of comment delimiter regexp."
   :group 'separedit
   :type 'alist)
@@ -222,6 +222,7 @@ Taken from `markdown-code-lang-modes'."
                                go-mode
                                java-mode
                                js-mode
+                               nix-mode
                                objc-mode
                                php-mode
                                rust-mode
@@ -363,6 +364,7 @@ Return nil if reached the end of the buffer."
 (defcustom separedit-string-quotes-alist
   '((python-mode     . ("\"\"\"" "'''" "\"" "'"))
     (js-mode         . ("\"" "'"))
+    (nix-mode        . ("''" "\""))
     (separedit-double-quote-string-mode . t)
     (separedit-single-quote-string-mode . ("'"))
     (t               . ("\"")))


### PR DESCRIPTION
This looks really useful especially for nix where you frequently have bash scripts within strings.

I didn't add any tests, since `nix-mode` is not part of Emacs and it was quite trivial.

I have two questions, that I should perhaps open issues for, but I will ask them here anyways for my convenience (sorry).

a) Is it possible to trigger a specific mode when editing a string, e.g. `sh-mode`.

b) Is it possible to edit the string without including the leading white-space, kind of like when you in `org-mode` have the setting `org-src-preserve-indentation` set to `nil` and `org-edit-src-content-indentation` set to `2`. And then after the editing of the source block it will indent it 2 levels relative to the ending `''`. This would be soo awesome for Nix, and I can see it useful in python docstrings as well.

Once again, thanks for this package, looks very well made.