### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/Cask-24
+++ b/Cask-24
@@ -6,7 +6,6 @@
 (files "*.el")
 
 (depends-on "dash")
-(depends-on "dash-functional")
 (depends-on "edit-indirect")
 
 (development

--- a/Cask-25
+++ b/Cask-25
@@ -6,7 +6,6 @@
 (files "*.el")
 
 (depends-on "dash")
-(depends-on "dash-functional")
 (depends-on "edit-indirect")
 
 (development

--- a/separedit.el
+++ b/separedit.el
@@ -5,7 +5,7 @@
 ;; Author: Gong Qijian <gongqijian@gmail.com>
 ;; Created: 2019/04/06
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "24.4") (dash "2.0") (dash-functional "1.2") (edit-indirect "0.1.5"))
+;; Package-Requires: ((emacs "24.4") (dash "2.18") (edit-indirect "0.1.5"))
 ;; URL: https://github.com/twlz0ne/separedit.el
 ;; Keywords: tools languages docs
 
@@ -302,7 +302,6 @@
 
 (require 'cl-lib)
 (require 'dash)
-(require 'dash-functional)
 (require 'edit-indirect)
 (require 'calc-misc)
 (require 'subr-x)


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218